### PR TITLE
fix(sdk-swap): get liquidity pool sdk calls will return default value instead of returning error

### DIFF
--- a/.changeset/bright-ears-unite.md
+++ b/.changeset/bright-ears-unite.md
@@ -1,0 +1,5 @@
+---
+"@bho-network/sdk-swap": patch
+---
+
+`getLiquidityPoolContract` will return `null` if the pool not existed yet.

--- a/.changeset/real-camels-remain.md
+++ b/.changeset/real-camels-remain.md
@@ -1,0 +1,5 @@
+---
+"@bho-network/sdk-swap": patch
+---
+
+`getLiquidityPoolReserves` will return (0,0) for not existed pool.


### PR DESCRIPTION
`getLiquidityPoolContract` and `getLiquidityPoolReserves` will return default value instead of returning error